### PR TITLE
#35 도소탐 문제 출제 로직 변경

### DIFF
--- a/config/DDL.sql
+++ b/config/DDL.sql
@@ -178,6 +178,16 @@ CREATE TABLE `game_challenge` (
                                     CONSTRAINT `game_challenge_CK2` CHECK (`difficulty` IN ('LEVEL_1', 'LEVEL_2', 'LEVEL_3'))
 ) COMMENT = '도전 소리 탐정';
 
+CREATE TABLE `game_challenge_schedule` (
+                                  `challenge_schedule_id`   INT AUTO_INCREMENT              NOT NULL COMMENT '출제 기록 번호',
+                                  `challenge_id`            INT                             NOT NULL COMMENT '도소탐 번호',
+                                  `schedule`                DATE DEFAULT CURRENT_TIMESTAMP  NOT NULL COMMENT '출제 날짜',
+                                  #PK
+                                  PRIMARY KEY (`challenge_schedule_id`),
+                                  #FK
+                                  FOREIGN KEY (`challenge_id`) REFERENCES `game_challenge` (`challenge_id`)
+) COMMENT = '도전 소리 탐정 출제 기록';
+
 -- Game_whisper 테이블
 CREATE TABLE `game_whisper` (
                                 `whisper_id`        INT AUTO_INCREMENT                  NOT NULL COMMENT '고요침 번호',

--- a/src/main/java/com/sorisonsoon/SorisonsoonApplication.java
+++ b/src/main/java/com/sorisonsoon/SorisonsoonApplication.java
@@ -3,7 +3,9 @@ package com.sorisonsoon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class SorisonsoonApplication {

--- a/src/main/java/com/sorisonsoon/gameChallenge/controller/GameChallengeController.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/controller/GameChallengeController.java
@@ -2,6 +2,7 @@ package com.sorisonsoon.gameChallenge.controller;
 
 import com.sorisonsoon.common.domain.type.GameDifficulty;
 import com.sorisonsoon.gameChallenge.dto.request.SoundResultRequest;
+import com.sorisonsoon.gameChallenge.dto.response.SoundCorrectResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundQuestionResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundRecordResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundResultResponse;
@@ -19,10 +20,20 @@ public class GameChallengeController {
 
     private final GameChallengeService gameChallengeService;
 
-    @GetMapping("/game-start")
-    public ResponseEntity<SoundQuestionResponse> gameStart(@RequestParam GameDifficulty difficulty) {
+    @GetMapping("/check-correct")
+    public ResponseEntity<SoundCorrectResponse> checkCorrect() {
+        // Test 데이터
+        Long userId = 1L;
 
-        SoundQuestionResponse question = gameChallengeService.getSoundQuestion(difficulty);
+        SoundCorrectResponse result = gameChallengeService.checkCorrect(userId);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/game-start")
+    public ResponseEntity<SoundQuestionResponse> gameStart() {
+
+        SoundQuestionResponse question = gameChallengeService.getSoundQuestion();
 
         return ResponseEntity.ok(question);
     }

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/entity/GameChallenge.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/entity/GameChallenge.java
@@ -4,9 +4,11 @@ import com.sorisonsoon.gameChallenge.domain.type.GameChallengeCategory;
 import com.sorisonsoon.common.domain.type.GameDifficulty;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "game_challenge")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameChallenge {

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/entity/GameChallengeSchedule.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/entity/GameChallengeSchedule.java
@@ -1,0 +1,27 @@
+package com.sorisonsoon.gameChallenge.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "game_challenge_schedule")
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameChallengeSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long challengeScheduleId;
+
+    private Long challengeId;
+
+    private LocalDate schedule;
+
+    public GameChallengeSchedule(Long challengeId) {
+        this.challengeId = challengeId;
+    }
+}

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryCustom.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryCustom.java
@@ -1,6 +1,8 @@
 package com.sorisonsoon.gameChallenge.domain.repository;
 
 import com.sorisonsoon.common.domain.type.GameDifficulty;
+import com.sorisonsoon.gameChallenge.domain.entity.GameChallenge;
+import com.sorisonsoon.gameChallenge.dto.response.SoundCorrectResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundQuestionResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundRecordResponse;
 
@@ -8,7 +10,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface GameChallengeRepositoryCustom {
-    Optional<SoundQuestionResponse> getQuestionByDifficulty(GameDifficulty difficulty);
+    Optional<SoundQuestionResponse> getTodayQuestion();
 
     List<SoundRecordResponse> getSoundRecords(Long challengeId);
+
+    GameChallenge getUnscheduledQuestion();
+
+    SoundCorrectResponse checkCorrect(Long userId);
 }

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryImpl.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryImpl.java
@@ -1,17 +1,22 @@
 package com.sorisonsoon.gameChallenge.domain.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sorisonsoon.common.domain.type.GameDifficulty;
+import com.sorisonsoon.gameChallenge.domain.entity.GameChallenge;
+import com.sorisonsoon.gameChallenge.dto.response.SoundCorrectResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundQuestionResponse;
 import com.sorisonsoon.gameChallenge.dto.response.SoundRecordResponse;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import static com.sorisonsoon.gameChallenge.domain.entity.QGameChallenge.gameChallenge;
+import static com.sorisonsoon.gameChallenge.domain.entity.QGameChallengeSchedule.gameChallengeSchedule;
 import static com.sorisonsoon.record.domain.entity.QRecord.record;
 
 @RequiredArgsConstructor
@@ -19,17 +24,58 @@ public class GameChallengeRepositoryImpl implements GameChallengeRepositoryCusto
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<SoundQuestionResponse> getQuestionByDifficulty(GameDifficulty difficulty) {
+    public GameChallenge getUnscheduledQuestion() {
+        LocalDate oneMonthAgo = LocalDate.now().minusMonths(1);
+
+        return queryFactory
+                .selectFrom(gameChallenge)
+                .leftJoin(gameChallengeSchedule).on(gameChallenge.challengeId.eq(gameChallengeSchedule.challengeId))
+                .where(
+                        gameChallengeSchedule.schedule.lt(oneMonthAgo)
+                                .or(gameChallengeSchedule.schedule.isNull())
+                )
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    @Override
+    public SoundCorrectResponse checkCorrect(Long userId) {
+        Long challengeId = queryFactory
+                .select(gameChallenge.challengeId)
+                .from(gameChallenge)
+                .leftJoin(gameChallengeSchedule).on(gameChallenge.challengeId.eq(gameChallengeSchedule.challengeId))
+                .where(gameChallengeSchedule.schedule.eq(LocalDate.now()))
+                .fetchOne();
+
+        Boolean exists = queryFactory
+                .selectOne()
+                .from(record)
+                .where(record.playerId.eq(userId)
+                        .and(record.challengeId.eq(challengeId))
+                        .and(record.isCorrect.eq(Boolean.TRUE)))
+                .fetchFirst() != null;
+
+        GameDifficulty difficulty = queryFactory
+                .select(gameChallenge.difficulty)
+                .from(gameChallenge)
+                .where(gameChallenge.challengeId.eq(challengeId))
+                .fetchOne();
+
+        return new SoundCorrectResponse(exists, difficulty);
+    }
+
+    @Override
+    public Optional<SoundQuestionResponse> getTodayQuestion() {
         SoundQuestionResponse result = queryFactory
                 .select(Projections.constructor(SoundQuestionResponse.class,
                         gameChallenge.challengeId,
-                        gameChallenge.question
-//                        gameChallenge.question
+                        gameChallenge.question,
+                        gameChallenge.difficulty
                 ))
                 .from(gameChallenge)
-                .where(gameChallenge.difficulty.eq(difficulty))
-                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
-                .limit(1)
+                .leftJoin(gameChallengeSchedule).on(gameChallenge.challengeId.eq(gameChallengeSchedule.challengeId))
+                .where(gameChallengeSchedule.schedule.eq(LocalDate.now()))
                 .fetchOne();
 
         return Optional.ofNullable(result);
@@ -47,4 +93,6 @@ public class GameChallengeRepositoryImpl implements GameChallengeRepositoryCusto
                 .orderBy(record.similarity.desc())
                 .fetch();
     }
+
+
 }

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeScheduleRepository.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.sorisonsoon.gameChallenge.domain.repository;
+
+import com.sorisonsoon.gameChallenge.domain.entity.GameChallengeSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameChallengeScheduleRepository extends JpaRepository<GameChallengeSchedule, Long> {
+}

--- a/src/main/java/com/sorisonsoon/gameChallenge/dto/response/SoundCorrectResponse.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/dto/response/SoundCorrectResponse.java
@@ -6,8 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class SoundQuestionResponse {
-    private final Long challengeId;
-    private final String url;
+public class SoundCorrectResponse {
+    private final Boolean isCorrect;
     private final GameDifficulty difficulty;
 }


### PR DESCRIPTION
<!-- --------------------------------------------------------- -->
<!-- 제목 작성 규칙✅ : #이슈번호 이슈명 -->
<!-- [예시] #23 로그인 페이지 추가 -->
<!-- --------------------------------------------------------- -->


### 📫 PR 유형
<!-- 하나 이상의 PR 타입을 선택해주세요. -->
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능 -->
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 개요
<!-- 개요 작성 규칙✅ : PR 개요 및 이슈 번호를 입력하세요. --> 
<!-- 단, 종료된 이슈라면 closed #{이슈번호} 형태로 입력하세요. --> 
<!-- [예시] 🚀 #21 -->
> 도소탐의 문제 출제 로직을 변경했어요
- closed #35 

## 💻 작업 내용

- DDL에 도소탐 문제 출제 테이블 생성 구문을 추가했어요
- 출제 테이블의 엔터티를 만들고, 그날의 문제 설정을 위한 Spring Scheduler 메소드를 작성했어요
- 매일 자정, 문제 하나를 가져오고 오늘 날짜를 설정하는 기능을 구현했어요
- 기존 /game-start 엔드포인트를 오늘 문제를 가져오는 방향으로 수정했어요.
- 정답 기록이 있는지 확인하는 기능을 구현했어요.

## 📚 참고
<!-- (선택사항) 작성이 필요한 경우만 추가 -->


<!-- --------------------------------------------------------- -->
<!-- PR 작성 시 확인 목록✅ -->
<!-- 1) 이슈와 기능에 맞는 라벨(label) 선택 -->
<!-- 2) 프로젝트(project) 선택 -->
<!-- 3) 마일스톤(milestone)선택 -->
<!-- --------------------------------------------------------- -->
