### PR TITLE
#50 맞수수 랭킹 및 플레이 기록 저장

### DIFF
--- a/src/main/java/com/sorisonsoon/gameriddle/controller/GameRiddleController.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/controller/GameRiddleController.java
@@ -1,15 +1,14 @@
 package com.sorisonsoon.gameriddle.controller;
 
 import com.sorisonsoon.common.domain.type.GameDifficulty;
+import com.sorisonsoon.gameriddle.dto.request.GameFinishRequest;
 import com.sorisonsoon.gameriddle.dto.response.HandQuestionResponse;
 import com.sorisonsoon.gameriddle.service.GameRiddleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -41,5 +40,15 @@ public class GameRiddleController {
         String video = gameRiddleService.getQuestionVideo(riddleId);
 
         return ResponseEntity.ok(video);
+    }
+
+    @PostMapping("/game-finish")
+    public ResponseEntity<Void> gameFinish(@RequestBody List<GameFinishRequest> finishRequest) {
+        // Test 데이터 @AuthenticationPrincipal
+        Long userId = 1L;
+
+        gameRiddleService.gameFinish(userId, finishRequest);
+
+        return ResponseEntity.created(URI.create("api/v1/")).build();
     }
 }

--- a/src/main/java/com/sorisonsoon/gameriddle/dto/request/GameFinishRequest.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/dto/request/GameFinishRequest.java
@@ -1,0 +1,13 @@
+package com.sorisonsoon.gameriddle.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GameFinishRequest {
+    private final Long riddleId;
+    private final String question;
+    private final Long totalStep;
+    private final Boolean isCorrect;
+}

--- a/src/main/java/com/sorisonsoon/record/domain/entity/RecordRiddle.java
+++ b/src/main/java/com/sorisonsoon/record/domain/entity/RecordRiddle.java
@@ -1,0 +1,63 @@
+package com.sorisonsoon.record.domain.entity;
+
+import com.sorisonsoon.common.domain.type.GameCategory;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "record_riddle")
+@DynamicInsert
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordRiddle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_id")
+    private Long recordId;
+
+    private Long playerId;
+    private Long riddleId;
+
+    @Enumerated(EnumType.STRING)
+    private GameCategory category;
+
+    private Boolean isCorrect;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+
+    private RecordRiddle(
+            Long playerId,
+            Long riddleId,
+            GameCategory category,
+            Boolean isCorrect
+    ) {
+        this.playerId = playerId;
+        this.riddleId = riddleId;
+        this.category = category;
+        this.isCorrect = isCorrect;
+    }
+
+
+    public static RecordRiddle of(
+            Long playerId, Long riddleId, GameCategory category, Boolean isCorrect
+    ) {
+        return new RecordRiddle(
+                playerId,
+                riddleId,
+                category,
+                isCorrect
+        );
+    }
+
+}

--- a/src/main/java/com/sorisonsoon/record/domain/repository/RecordRiddleRepository.java
+++ b/src/main/java/com/sorisonsoon/record/domain/repository/RecordRiddleRepository.java
@@ -1,0 +1,9 @@
+package com.sorisonsoon.record.domain.repository;
+
+
+import com.sorisonsoon.record.domain.entity.RecordRiddle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface RecordRiddleRepository extends JpaRepository<RecordRiddle, Long>{
+}


### PR DESCRIPTION
<!-- --------------------------------------------------------- -->
<!-- 제목 작성 규칙✅ : #이슈번호 이슈명 -->
<!-- [예시] #23 로그인 페이지 추가 -->
<!-- --------------------------------------------------------- -->


### 📫 PR 유형
<!-- 하나 이상의 PR 타입을 선택해주세요. -->
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 개요
<!-- 개요 작성 규칙✅ : PR 개요 및 이슈 번호를 입력하세요. --> 
<!-- 단, 종료된 이슈라면 closed #{이슈번호} 형태로 입력하세요. --> 
<!-- [예시] 🚀 #21 -->
> 맞수수 랭킹과 플레이 기록을 저장하는 기능을 구현했어요.
- closed #50 

## 💻 작업 내용
- 맞수수 플레이 기록을 저장하는 기능을 구현했어요.
- 맞수수 랭킹을 저장하는 기능을 구현했어요.

## 📚 참고
<!-- (선택사항) 작성이 필요한 경우만 추가 -->


<!-- --------------------------------------------------------- -->
<!-- PR 작성 시 확인 목록✅ -->
<!-- 1) 이슈와 기능에 맞는 라벨(label) 선택 -->
<!-- 2) 프로젝트(project) 선택 -->
<!-- 3) 마일스톤(milestone)선택 -->
<!-- --------------------------------------------------------- -->
