### PR TITLE
#61 맞수수 가이드 이미지 오류 해결 및 모델 평가 방법 변경 및 도소탐 제출 기능 수정

### DIFF
--- a/src/main/java/com/sorisonsoon/gameChallenge/controller/GameChallengeController.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/controller/GameChallengeController.java
@@ -57,4 +57,26 @@ public class GameChallengeController {
 
         return ResponseEntity.ok(result);
     }
+
+    @PostMapping("/reset-answer")
+    public ResponseEntity<Void> resetAnswer() {
+        // Test 데이터 @AuthenticationPrincipal
+        Long userId = 1L;
+
+        gameChallengeService.resetUserAnswer(userId);
+
+        return ResponseEntity.ok().build();
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryCustom.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryCustom.java
@@ -18,3 +18,5 @@ public interface GameChallengeRepositoryCustom {
 
     SoundCorrectResponse checkCorrect(Long userId);
 }
+
+

--- a/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryImpl.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/domain/repository/GameChallengeRepositoryImpl.java
@@ -99,3 +99,12 @@ public class GameChallengeRepositoryImpl implements GameChallengeRepositoryCusto
 
 
 }
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/sorisonsoon/gameChallenge/service/GameChallengeService.java
+++ b/src/main/java/com/sorisonsoon/gameChallenge/service/GameChallengeService.java
@@ -108,4 +108,22 @@ public class GameChallengeService {
 
         return new SoundResultResponse(isCorrect, similarity);
     }
+
+    public void resetUserAnswer(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        // 특정 시간 동안 사용자가 제출한 최근의 기록을 삭제합니다.
+        recordRepository.deleteAllByPlayerIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
+    }
 }
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/sorisonsoon/gameriddle/controller/GameRiddleController.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/controller/GameRiddleController.java
@@ -52,3 +52,6 @@ public class GameRiddleController {
         return ResponseEntity.created(URI.create("api/v1/")).build();
     }
 }
+
+
+

--- a/src/main/java/com/sorisonsoon/gameriddle/domain/repository/GameRiddleRepository.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/domain/repository/GameRiddleRepository.java
@@ -7,3 +7,5 @@ public interface GameRiddleRepository extends JpaRepository<GameRiddle, Long>, G
 
     GameRiddle findByRiddleId(Long riddleId);
 }
+
+

--- a/src/main/java/com/sorisonsoon/gameriddle/domain/repository/GameRiddleRepositoryCustom.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/domain/repository/GameRiddleRepositoryCustom.java
@@ -11,3 +11,6 @@ public interface GameRiddleRepositoryCustom {
 
     List<HandQuestionResponse> getRiddlesByDifficulty(GameDifficulty difficulty, Long totalQuestion);
 }
+
+
+

--- a/src/main/java/com/sorisonsoon/gameriddle/domain/repository/GameRiddleRepositoryImpl.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/domain/repository/GameRiddleRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sorisonsoon.common.domain.type.GameDifficulty;
 import com.sorisonsoon.gameriddle.dto.response.HandQuestionResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
@@ -13,25 +14,53 @@ import static com.sorisonsoon.gameriddle.domain.entity.QGameRiddle.gameRiddle;
 import static com.sorisonsoon.gameriddle.domain.entity.QGameRiddleStep.gameRiddleStep;
 
 @RequiredArgsConstructor
+@Repository
 public class GameRiddleRepositoryImpl implements GameRiddleRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
 
     @Override
     public List<HandQuestionResponse> getRiddlesByDifficulty(GameDifficulty difficulty, Long totalQuestion) {
-        return queryFactory
+        System.out.println("getRiddlesByDifficulty called with difficulty: " + difficulty + ", totalQuestion: " + totalQuestion);
+
+        List<HandQuestionResponse> result = queryFactory
                 .select(Projections.constructor(HandQuestionResponse.class,
                         gameRiddle.riddleId,
                         gameRiddle.question,
-                        gameRiddleStep.riddleStepId.count()
+                        gameRiddleStep.riddleStepId.count().as("stepCount")
                 ))
                 .from(gameRiddle)
                 .leftJoin(gameRiddleStep).on(gameRiddle.riddleId.eq(gameRiddleStep.riddleId))
-                .where(
-                        gameRiddle.difficulty.eq(difficulty)
-                )
+                .where(gameRiddle.difficulty.eq(difficulty))
                 .groupBy(gameRiddle.riddleId)
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .limit(totalQuestion)
                 .fetch();
+
+        System.out.println("Fetched riddles:");
+        for (HandQuestionResponse riddle : result) {
+            System.out.println("Riddle ID: " + riddle.getRiddleId() + ", Question: " + riddle.getQuestion() + ", Step Count: " + riddle.getTotalStep());
+        }
+
+        return result;
+    }
+
+    public String getQuestionImage(Long riddleId, Long step) {
+        System.out.println("getQuestionImage called with riddleId: " + riddleId + ", step: " + step);
+
+        String questionImage = queryFactory
+                .select(gameRiddleStep.answer)
+                .from(gameRiddleStep)
+                .where(gameRiddleStep.riddleId.eq(riddleId)
+                        .and(gameRiddleStep.step.eq(step)))
+                .fetchOne();
+
+        if (questionImage != null) {
+            System.out.println("Fetched Question Image: " + questionImage);
+        } else {
+            System.out.println("No Question found for riddleId: " + riddleId + ", step: " + step);
+        }
+
+        return questionImage;
     }
 }

--- a/src/main/java/com/sorisonsoon/gameriddle/service/GameRiddleService.java
+++ b/src/main/java/com/sorisonsoon/gameriddle/service/GameRiddleService.java
@@ -10,7 +10,6 @@ import com.sorisonsoon.gameriddle.dto.request.GameFinishRequest;
 import com.sorisonsoon.gameriddle.dto.response.HandQuestionResponse;
 import com.sorisonsoon.ranking.service.RankingService;
 import com.sorisonsoon.record.domain.entity.RecordRiddle;
-import com.sorisonsoon.record.domain.repository.RecordRepository;
 import com.sorisonsoon.record.domain.repository.RecordRiddleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,18 +30,18 @@ public class GameRiddleService {
     @Transactional(readOnly = true)
     public List<HandQuestionResponse> getGameRiddles(GameDifficulty difficulty, Long totalQuestion) {
         return gameRiddleRepository.getRiddlesByDifficulty(difficulty, totalQuestion);
-    };
+    }
 
     @Transactional(readOnly = true)
     public String getQuestionImage(Long riddleId, Long step) {
         GameRiddleStep question = gameRiddleStepRepository.findByRiddleIdAndStep(riddleId, step);
-        return question.getAnswer();
+        return question != null ? question.getAnswer() : null;
     }
 
     @Transactional(readOnly = true)
     public String getQuestionVideo(Long riddleId) {
         GameRiddle question = gameRiddleRepository.findByRiddleId(riddleId);
-        return question.getVideo();
+        return question != null ? question.getVideo() : null;
     }
 
     public void gameFinish(Long userId, List<GameFinishRequest> finishRequest) {
@@ -67,3 +66,5 @@ public class GameRiddleService {
         rankingService.save(userId, GameCategory.RIDDLE, score);
     }
 }
+
+

--- a/src/main/java/com/sorisonsoon/record/domain/repository/RecordRepositoryCustom.java
+++ b/src/main/java/com/sorisonsoon/record/domain/repository/RecordRepositoryCustom.java
@@ -1,6 +1,9 @@
 package com.sorisonsoon.record.domain.repository;
 
+import java.time.LocalDateTime;
+
 public interface RecordRepositoryCustom {
 
+    void deleteAllByPlayerIdAndCreatedAtBetween(Long playerId, LocalDateTime start, LocalDateTime end);
 
 }

--- a/src/main/java/com/sorisonsoon/record/domain/repository/RecordRepositoryImpl.java
+++ b/src/main/java/com/sorisonsoon/record/domain/repository/RecordRepositoryImpl.java
@@ -2,10 +2,24 @@ package com.sorisonsoon.record.domain.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import com.sorisonsoon.record.domain.entity.QRecord;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 public class RecordRepositoryImpl implements RecordRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
 
+    @Override
+    public void deleteAllByPlayerIdAndCreatedAtBetween(Long playerId, LocalDateTime start, LocalDateTime end) {
+        QRecord record = QRecord.record;
 
+        // 해당 플레이어의 주어진 시간 범위 내의 모든 레코드를 삭제합니다.
+        queryFactory
+            .delete(record)
+            .where(record.playerId.eq(playerId)
+                .and(record.createdAt.between(start, end)))
+            .execute();
+    }
 }


### PR DESCRIPTION
<!-- --------------------------------------------------------- -->
<!-- 제목 작성 규칙✅ : #이슈번호 이슈명 -->
<!-- [예시] #23 로그인 페이지 추가 -->
<!-- --------------------------------------------------------- -->


### 📫 PR 유형
<!-- 하나 이상의 PR 타입을 선택해주세요. -->
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능 -->
- [X] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 개요
<!-- 개요 작성 규칙✅ : PR 개요 및 이슈 번호를 입력하세요. --> 
<!-- 단, 종료된 이슈라면 closed #{이슈번호} 형태로 입력하세요. --> 
<!-- [예시] 🚀 #21 -->
> 간단한 개요 작성해주세요. 
- closed #60 

## 💻 작업 내용
- 모델의 평가 방법을 가장 높은 정확도를 가지는 클래스가 아닌 top3의 정확도를 가지는 클래스까지 정답으로 판단
- 도소탐에서 그 날의 모든 사용자 정답 제출 기록이 페이지에서 나가면 DB의 record 테이블에서 사라지도록 구현
- 맞수수에서 첫 문제에 대한 가이드 이미지가 고정되는 문제 해결

## 📚 참고
<!-- (선택사항) 작성이 필요한 경우만 추가 -->


<!-- --------------------------------------------------------- -->
<!-- PR 작성 시 확인 목록✅ -->
<!-- 1) 이슈와 기능에 맞는 라벨(label) 선택 -->
<!-- 2) 프로젝트(project) 선택 -->
<!-- 3) 마일스톤(milestone)선택 -->
<!-- --------------------------------------------------------- -->
